### PR TITLE
fix/prometheus-deprecated-field

### DIFF
--- a/integrations/prometheus/prometheus.md
+++ b/integrations/prometheus/prometheus.md
@@ -43,8 +43,8 @@ route:
   receiver: prometheus-signl4
   repeat_interval: 10m
   routes:
-  - match:
-      alertname: Watchdog
+  - matchers:
+      - alertname = "Watchdog"
     receiver: prometheus-signl4
 ```
 


### PR DESCRIPTION
### Replace deprecated 'match' with 'matchers' in Alertmanager routes

The 'match' field in Alertmanager routes is deprecated according to Prometheus documentation. This update replaces it with the 'matchers' field, ensuring compatibility with the latest config. After using this code snippet from the documentation and applying it, i've noticed the alertmanager was rejecting this config.

Heres the prometheus documentation entry: 
https://prometheus.io/docs/alerting/latest/configuration/#route